### PR TITLE
build: add awscli to environment to allow uploading images to s3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ COPY gitconfig /home/builder/.gitconfig
 RUN mkdir /home/builder/.ssh \
     && chown builder:builder /home/builder/.ssh \
     && mkdir /home/builder/output \
-    && chown builder:builder /home/builder/output
+    && chown builder:builder /home/builder/output \
+    && pip3 install --no-cache-dir awscli==1.25.90
 
 WORKDIR /home/builder/
 


### PR DESCRIPTION
* to allow to easily upload images to aws s3 repositories, we need to include awscli in our environment
* pin version to current latest (1.25.90) to avoid spontaneous upgrades or pulling in any non functional versions

Signed-off-by: Jan Klare <jan.klare@bisdn.de>