### PR TITLE
build: update versions based on latest template

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,15 +33,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
+      # Set up a Docker Buildx
+      # https://github.com/docker/setup-buildx-action
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v2
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -51,7 +52,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta-base
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base
 
@@ -59,7 +60,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta-ci
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ci
 
@@ -67,7 +68,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image target base
         id: build-and-push-base
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v4
         with:
           target: base
           context: .
@@ -81,7 +82,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image target ci
         id: build-and-push-ci
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v4
         with:
           target: ci
           context: .


### PR DESCRIPTION
Update versions based on latest template [1] resp. their latest versions instead of hardcoding certain commits.

drops the workaround for buildx since the issue has been fixed.

Should silence the warnings about node 12 deprecation [2].

Depends on https://github.com/bisdn/docker-yocto-builder/pull/6

[1] https://github.com/marketplace/actions/build-and-push-docker-images
[2] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/