### PR TITLE
ci: allow arbitrary length footnotes in commit bodies

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: { 'footer-max-line-length': [1, 'always', 100] },
+  parserPreset: {
+    parserOpts: {
+      noteKeywords: ['\\[\\d+\\]']
+    }
+  }
+}


### PR DESCRIPTION
Sometimes URIs need to be added in a commit, and splitting them up is undesired, as they make checking them harder. But often URIs tend to get longer than 80 characters, triggering a failure from commitlint.

Work around this by adapting the example from [1], by defining everything starting with "[<num>] " as footer, and demote the error to warning.

[1] https://github.com/conventional-changelog/commitlint/issues/2112#issuecomment-692788007